### PR TITLE
Update tutorials theme url

### DIFF
--- a/tutorials/rpm-packaging/index.org
+++ b/tutorials/rpm-packaging/index.org
@@ -1,4 +1,4 @@
-#+SETUPFILE: https://fniessen.github.io/org-html-themes/setup/theme-readtheorg.setup
+#+SETUPFILE: https://fniessen.github.io/org-html-themes/org/theme-readtheorg.setup
 #+TITLE: RPM Packaging Tutorial
 #+DATE: 2017-03-08
 #+AUTHOR: Duncan Mac-Vicar P.


### PR DESCRIPTION
The setupfile moved from /setup/theme-name.setup to /org/theme-name.setup.

Using this patch + running `./build.sh` brings ReadTheOrg back:
![image](https://user-images.githubusercontent.com/19352524/137556927-b6da701c-4d05-4959-8aef-439108580f15.png)
